### PR TITLE
Fix broken redirect string

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <a href="/dev">Click here if you are not redirected</a>
 
 <script>
-window.location.pathname = "/dev
+window.location.pathname = "/dev"
 </script>


### PR DESCRIPTION
Automatic redirection on the docs was not working because of a missing double quote