### PR TITLE
Add delete_all_messages() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install roblox
 
 To install the latest unstable version of ro.py, install [git-scm](https://git-scm.com/downloads) and run the following:
 ```
-pip install git+git://github.com/ro-py/ro.py.git
+pip install git+https://github.com/ro-py/ro.py.git
 ```
 
 # Tutorial

--- a/roblox/bases/basegroup.py
+++ b/roblox/bases/basegroup.py
@@ -283,8 +283,8 @@ class BaseGroup(BaseItem):
         Arguments:
             user: The user who will have their messages deleted.
         """
-        await self._shared.requests.delete(
-            url=self._shared.url_generator.get_url("groups", f"/v1/groups/{self.id}/wall/users/{int(user)}/posts")
+        await self._client.requests.delete(
+            url=self._client.url_generator.get_url("groups", f"/v1/groups/{self.id}/wall/users/{int(user)}/posts")
 
     def get_wall_posts(self, page_size: int = 10, sort_order: SortOrder = SortOrder.Ascending,
                        max_items: int = None) -> PageIterator:

--- a/roblox/bases/basegroup.py
+++ b/roblox/bases/basegroup.py
@@ -276,6 +276,16 @@ class BaseGroup(BaseItem):
             url=self._client.url_generator.get_url("groups", f"v1/groups/{self.id}/users/{int(user)}")
         )
 
+    async def delete_all_messages(self, user: UserOrUserId):
+        """
+        Deletes all messages from a user in a group.
+
+        Arguments:
+            user: The user who will have their messages deleted.
+        """
+        await self._shared.requests.delete(
+            url=self._shared.url_generator.get_url("groups", f"/v1/groups/{self.id}/wall/users/{int(user)}/posts")
+
     def get_wall_posts(self, page_size: int = 10, sort_order: SortOrder = SortOrder.Ascending,
                        max_items: int = None) -> PageIterator:
         """

--- a/roblox/bases/basegroup.py
+++ b/roblox/bases/basegroup.py
@@ -285,6 +285,7 @@ class BaseGroup(BaseItem):
         """
         await self._client.requests.delete(
             url=self._client.url_generator.get_url("groups", f"/v1/groups/{self.id}/wall/users/{int(user)}/posts")
+        )
 
     def get_wall_posts(self, page_size: int = 10, sort_order: SortOrder = SortOrder.Ascending,
                        max_items: int = None) -> PageIterator:

--- a/roblox/members.py
+++ b/roblox/members.py
@@ -59,6 +59,12 @@ class MemberRelationship(BaseUser):
         Kicks this member from the group.
         """
         await self.group.kick_user(self)
+        
+    async def deleteallmessages(self):
+        """
+        Deletes all posts created by this member in the group.
+        """
+        await self.group.delete_all_messages(self)
 
 
 class Member(MemberRelationship):

--- a/roblox/members.py
+++ b/roblox/members.py
@@ -60,9 +60,9 @@ class MemberRelationship(BaseUser):
         """
         await self.group.kick_user(self)
         
-    async def deleteallmessages(self):
+    async def delete_all_messages(self):
         """
-        Deletes all posts created by this member in the group.
+        Deletes all wall posts created by this member in the group.
         """
         await self.group.delete_all_messages(self)
 


### PR DESCRIPTION
Deletes all messages by a specific user in a group. This doesn't kick anyone from the specified Roblox group.

Very helpful for things like moderation bots.

I changed basegroup and roblox.members