### PR TITLE
Fix: 404 Not Found when using .get_instances() #94

### DIFF
--- a/roblox/bases/baseplace.py
+++ b/roblox/bases/baseplace.py
@@ -75,13 +75,13 @@ class BasePlace(BaseAsset):
         Grabs the place's servers.
 
         Arguments:
-            server_type: The type of servers to return
+            server_type: The type of servers to return.
             page_size: How many servers should be returned for each page.
             sort_order: Order in which data should be grabbed.
             exclude_full_games: Whether to exclude full servers.
             max_items: The maximum items to return when looping through this object.
         Returns:
-            A PageIterator containing the place's servers.
+            A PageIterator containing servers.
         """
         from ..jobs import Server
 

--- a/roblox/bases/baseplace.py
+++ b/roblox/bases/baseplace.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ..bases.baseasset import BaseAsset
+from ..utilities.iterators import PageIterator, SortOrder
 
 if TYPE_CHECKING:
     from ..client import Client
+    from ..jobs import ServerType
 
 
 class BasePlace(BaseAsset):
@@ -40,6 +42,9 @@ class BasePlace(BaseAsset):
         This list always contains 10 items or fewer.
         For more items, add 10 to the start index and repeat until no more items are available.
 
+        !!! warning
+            This method has been deprecated. Please rectify any code that uses this method.        
+
         Arguments:
             start_index: Where to start in the server index.
         """
@@ -56,4 +61,63 @@ class BasePlace(BaseAsset):
         return GameInstances(
             client=self._client,
             data=instances_data
+        )
+
+    def get_servers(
+            self,
+            server_type: ServerType,
+            page_size: int = 10, 
+            sort_order: SortOrder = SortOrder.Descending, 
+            exclude_full_games: bool = False,
+            max_items: int = None
+    ) -> PageIterator:
+        """
+        Grabs the place's servers.
+
+        Arguments:
+            server_type: The type of servers to return
+            page_size: How many servers should be returned for each page.
+            sort_order: Order in which data should be grabbed.
+            exclude_full_games: Whether to exclude full servers.
+            max_items: The maximum items to return when looping through this object.
+        Returns:
+            A PageIterator containing the place's servers.
+        """
+        from ..jobs import Server
+
+        return PageIterator(
+            client=self._client,
+            url=self._client._url_generator.get_url("games", f"v1/games/{self.id}/servers/{server_type.value}"),
+            page_size=page_size,
+            max_items=max_items,
+            sort_order=sort_order,
+            extra_parameters={"excludeFullGames": exclude_full_games},
+            handler=lambda client, data: Server(client=client, data=data),
+        )
+    
+    def get_private_servers(
+            self,
+            page_size: int = 10, 
+            sort_order: SortOrder = SortOrder.Descending, 
+            max_items: int = None
+    ) -> PageIterator:
+        """
+        Grabs the private servers of a place the authenticated user can access.
+
+        Arguments:
+            page_size: How many private servers should be returned for each page.
+            sort_order: Order in which data should be grabbed.
+            max_items: The maximum items to return when looping through this object.
+        Returns:
+            A PageIterator containing private servers.
+        """
+        from ..jobs import PrivateServer
+
+        return PageIterator(
+            client=self._client,
+            url=self._client._url_generator.get_url("games", f"v1/games/{self.id}/private-servers"),
+            page_size=page_size,
+            max_items=max_items,
+            sort_order=sort_order,
+            handler=lambda client, data: PrivateServer(client=client, data=data),
         )

--- a/roblox/jobs.py
+++ b/roblox/jobs.py
@@ -230,6 +230,7 @@ class Server:
         if isinstance(other, self.__class__): return other.id != self.id
 
         return True
+
     
 class PrivateServer(Server):
     """

--- a/roblox/jobs.py
+++ b/roblox/jobs.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from roblox.client import Client
-
 if TYPE_CHECKING:
     from .client import Client
 

--- a/roblox/jobs.py
+++ b/roblox/jobs.py
@@ -159,7 +159,7 @@ class ServerType(Enum):
 
 class ServerPlayer(BaseUser):
     """
-    Represents a single player in a server.
+    Represents a player in a server.
     
     Attributes:
         id: The player's user id.
@@ -194,7 +194,7 @@ class Server:
         max_players: The maximum number of players that can be in the server at once.
         playing: The amount of players in the server.
         player_tokens: A list of thumbnail tokens for all the players in the server.
-        players: A list of ServerPlayer objects reprisenting the players in the server. Only friends of the authenticated user will be included in the list.
+        players: A list of ServerPlayer objects representing the players in the server. Only friends of the authenticated user will show up here.
         fps: The server's fps.
         ping: The server's ping.
     """
@@ -241,11 +241,12 @@ class PrivateServer(Server):
         max_players: The maximum number of players that can be in the server at once.
         playing: The amount of players in the server.
         player_tokens: A list of thumbnail tokens for all the players in the server.
-        players: A list of ServerPlayer objects reprisenting the players in the server. Only friends of the authenticated user will be included in the list.
+        players: A list of ServerPlayer objects representing the players in the server. Only friends of the authenticated user will show up here.
         fps: The server's fps.
+        ping: The server's ping.
         name: The private server's name.
         accessCode: The private server's access code.
-        owner: A PartialUser object reprisenting the owner of the private server.
+        owner: A PartialUser object representing the owner of the private server.
     """
 
     def __init__(self, client: Client, data: dict):

--- a/roblox/jobs.py
+++ b/roblox/jobs.py
@@ -18,7 +18,6 @@ from enum import Enum
 from .bases.basejob import BaseJob
 from .bases.baseplace import BasePlace
 from .bases.baseuser import BaseUser
-from .bases.baseitem import BaseItem
 from .partials.partialuser import PartialUser
 
 


### PR DESCRIPTION
**Closes issue #94** 

### Changes
* Deprecated get_instances method by adding a warning admonition to it's docstring.
* Added get_servers method to BasePlace object.
* Added get_private_servers method to BasePlace object.
* Added ServerType Enum.
* Added ServerPlayer object to represent players in a server.
* Added Server object to represent an active server.
* Added PrivateServer object to represent a private server.