### PR TITLE
Make generic BaseItem.__repr__ implementation

### DIFF
--- a/roblox/assets.py
+++ b/roblox/assets.py
@@ -184,6 +184,3 @@ class EconomyAsset(BaseAsset):
         self.minimum_membership_level: int = data["MinimumMembershipLevel"]
         self.content_rating_type_id: int = data["ContentRatingTypeId"]
         self.sale_availability_locations = data["SaleAvailabilityLocations"]
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r} type={self.type}>"

--- a/roblox/badges.py
+++ b/roblox/badges.py
@@ -36,7 +36,7 @@ class BadgeStatistics:
         self.win_rate_percentage: int = data["winRatePercentage"]
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} awarded_count={self.awarded_count}>"
+        return f"<{self.__class__.__name__} past_day_awarded_count={self.past_day_awarded_count} awarded_count={self.awarded_count} win_rate_percentage={self.win_rate_percentage}>"
 
 
 class Badge(BaseBadge):
@@ -80,6 +80,3 @@ class Badge(BaseBadge):
 
         self.statistics: BadgeStatistics = BadgeStatistics(data=data["statistics"])
         self.awarding_universe: PartialUniverse = PartialUniverse(client=client, data=data["awardingUniverse"])
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r}>"

--- a/roblox/bases/baseitem.py
+++ b/roblox/bases/baseitem.py
@@ -13,7 +13,8 @@ class BaseItem:
     id = None
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id}>"
+        attributes_repr = "".join(f" {key}={value!r}" for key, value in self.__dict__.items() if not key.startswith("_"))
+        return f"<{self.__class__.__name__}{attributes_repr}>"
 
     def __int__(self):
         return self.id

--- a/roblox/chat.py
+++ b/roblox/chat.py
@@ -34,7 +34,7 @@ class ChatSettings:
         self.is_connect_tab_enabled: bool = data["isConnectTabEnabled"]
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} chat_enabled={self.chat_enabled}>"
+        return f"<{self.__class__.__name__} chat_enabled={self.chat_enabled} is_active_chat_user={self.is_active_chat_user} is_connect_tab_enabled={self.is_connect_tab_enabled}>"
 
 
 class ChatProvider:

--- a/roblox/conversations.py
+++ b/roblox/conversations.py
@@ -54,7 +54,7 @@ class ConversationTitle:
         self.is_default_title: bool = data["isDefaultTitle"]
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} title_for_viewer={self.title_for_viewer!r}>"
+        return f"<{self.__class__.__name__} title_for_viewer={self.title_for_viewer!r} is_default_title={self.is_default_title}>"
 
 
 class Conversation(BaseConversation):
@@ -105,6 +105,3 @@ class Conversation(BaseConversation):
             client=client,
             data=data["conversationUniverse"]
         )
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} title={self.title!r}>"

--- a/roblox/friends.py
+++ b/roblox/friends.py
@@ -35,6 +35,3 @@ class Friend(User):
         self.presence_type: Optional[int] = data.get("presenceType")
         self.is_deleted: bool = data["isDeleted"]
         self.friend_frequent_rank: int = data["friendFrequentRank"]
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r} is_online={self.is_online}>"

--- a/roblox/gamepasses.py
+++ b/roblox/gamepasses.py
@@ -33,6 +33,3 @@ class GamePass(BaseGamePass):
         self.display_name: str = data["displayName"]
         # TODO: add product here
         self.price: Optional[int] = data["price"]
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r} price={self.price}>"

--- a/roblox/groups.py
+++ b/roblox/groups.py
@@ -59,9 +59,6 @@ class Group(BaseGroup):
         self.is_locked: bool = data.get("isLocked") or False
         self.has_verified_badge: bool = data["hasVerifiedBadge"]
 
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r} owner={self.owner}>"
-
     async def update_shout(self, message: str, update_self: bool = True) -> Tuple[Optional[Shout], Optional[Shout]]:
         """
         Updates the shout.

--- a/roblox/instances.py
+++ b/roblox/instances.py
@@ -47,9 +47,6 @@ class ItemInstance(BaseInstance):
 
         super().__init__(client=self._client, instance_id=data["instanceId"])
 
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r} type={self.type}>"
-
 
 class AssetInstance(ItemInstance):
     """
@@ -61,9 +58,6 @@ class AssetInstance(ItemInstance):
         super().__init__(client=self._client, data=data)
 
         self.asset: BaseAsset = BaseAsset(client=self._client, asset_id=data["id"])
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r} type={self.type} asset={self.asset}>"
 
 
 class BadgeInstance(ItemInstance):
@@ -77,9 +71,6 @@ class BadgeInstance(ItemInstance):
 
         self.badge: BaseBadge = BaseBadge(client=self._client, badge_id=data["id"])
 
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r} type={self.type} badge={self.badge}>"
-
 
 class GamePassInstance(ItemInstance):
     """
@@ -91,9 +82,6 @@ class GamePassInstance(ItemInstance):
         super().__init__(client=self._client, data=data)
 
         self.gamepass: BaseGamePass = BaseGamePass(client=self._client, gamepass_id=data["id"])
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r} type={self.type} gamepass={self.gamepass}>"
 
 
 instance_classes = {

--- a/roblox/jobs.py
+++ b/roblox/jobs.py
@@ -61,9 +61,6 @@ class GameInstancePlayer(BaseUser):
             data=data["Thumbnail"]
         )
 
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r}>"
-
 
 class GameInstance(BaseJob):
     """
@@ -114,9 +111,6 @@ class GameInstance(BaseJob):
 
         self.join_script: str = data["JoinScript"]
         self.app_join_script: str = data["RobloxAppJoinScript"]
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id!r} capacity{self.capacity}>"
 
 
 class GameInstances:

--- a/roblox/members.py
+++ b/roblox/members.py
@@ -92,6 +92,3 @@ class Member(MemberRelationship):
 
         self.role: PartialRole = PartialRole(client=self._client, data=data["role"])
         self.group: BaseGroup = group
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r} role={self.role}>"

--- a/roblox/partials/partialbadge.py
+++ b/roblox/partials/partialbadge.py
@@ -39,6 +39,3 @@ class PartialBadge(BaseBadge):
         super().__init__(client=client, badge_id=self.id)
 
         self.awarded: datetime = parse(data["awardedDate"])
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} awarded={self.awarded}>"

--- a/roblox/partials/partialgroup.py
+++ b/roblox/partials/partialgroup.py
@@ -41,9 +41,6 @@ class AssetPartialGroup(BaseGroup):
 
         super().__init__(client, self.id)
 
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r}>"
-
 
 class UniversePartialGroup(BaseGroup):
     """
@@ -69,6 +66,3 @@ class UniversePartialGroup(BaseGroup):
         self.has_verified_badge: bool = data["hasVerifiedBadge"]
 
         super().__init__(client, self.id)
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r}>"

--- a/roblox/partials/partialrole.py
+++ b/roblox/partials/partialrole.py
@@ -30,6 +30,3 @@ class PartialRole(BaseRole):
         super().__init__(client=self._client, role_id=self.id)
         self.name: str = data["name"]
         self.rank: int = data["rank"]
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r} rank={self.rank}>"

--- a/roblox/partials/partialuniverse.py
+++ b/roblox/partials/partialuniverse.py
@@ -39,9 +39,6 @@ class PartialUniverse(BaseUniverse):
         self.name: str = data["name"]
         self.root_place: BasePlace = BasePlace(client=client, place_id=data["rootPlaceId"])
 
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r}>"
-
 
 class ChatPartialUniverse(BaseUniverse):
     """

--- a/roblox/partials/partialuser.py
+++ b/roblox/partials/partialuser.py
@@ -40,9 +40,6 @@ class PartialUser(BaseUser):
         self.display_name: str = data.get("displayName")
         self.has_verified_badge: bool = data.get("hasVerifiedBadge", False) or data.get("HasVerifiedBadge", False)
 
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r} display_name={self.display_name!r}>"
-
 
 class RequestedUsernamePartialUser(PartialUser):
     """

--- a/roblox/places.py
+++ b/roblox/places.py
@@ -57,6 +57,3 @@ class Place(BasePlace):
         self.price: int = data["price"]
         self.image_token: str = data["imageToken"]
         self.has_verified_badge: bool = data["hasVerifiedBadge"]
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r}>"

--- a/roblox/plugins.py
+++ b/roblox/plugins.py
@@ -44,6 +44,3 @@ class Plugin(BasePlugin):
         self.version_id: int = data["versionId"]
         self.created: datetime = parse(data["created"])
         self.updated: datetime = parse(data["updated"])
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r}>"

--- a/roblox/robloxbadges.py
+++ b/roblox/robloxbadges.py
@@ -31,6 +31,3 @@ class RobloxBadge(BaseRobloxBadge):
         self.name: str = data["name"]
         self.description: str = data["description"]
         self.image_url: str = data["imageUrl"]
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} name={self.name!r}>"

--- a/roblox/roles.py
+++ b/roblox/roles.py
@@ -48,9 +48,6 @@ class Role(BaseRole):
         self.rank: int = data["rank"]
         self.member_count: Optional[int] = data.get("memberCount")
 
-    def __repr__(self):
-        return f"<{self.__class__.__name__} name={self.name!r} rank={self.rank} member_count={self.member_count}>"
-
     def get_members(self, page_size: int = 10, sort_order: SortOrder = SortOrder.Ascending,
                     max_items: int = None) -> PageIterator:
         """

--- a/roblox/sociallinks.py
+++ b/roblox/sociallinks.py
@@ -45,6 +45,3 @@ class SocialLink(BaseUniverseSocialLink):
         self.title: str = data["title"]
         self.url: str = data["url"]
         self.type: SocialLinkType = SocialLinkType(data["type"])
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} url={self.url!r} type={self.type!r} title={self.title!r}"

--- a/roblox/universes.py
+++ b/roblox/universes.py
@@ -123,6 +123,3 @@ class Universe(BaseUniverse):
         # gameRating seems to be null across all games, so I omitted it from this class.
         self.is_favorited_by_user: bool = data["isFavoritedByUser"]
         self.favorited_count: int = data["favoritedCount"]
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r} creator={self.creator}>"

--- a/roblox/users.py
+++ b/roblox/users.py
@@ -49,6 +49,3 @@ class User(BaseUser):
         self.description: str = data["description"]
         self.created: datetime = parse(data["created"])
         self.has_verified_badge: bool = data["hasVerifiedBadge"]
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r} display_name={self.display_name!r}>"


### PR DESCRIPTION
This PR changes the implementation of `BaseItem.__repr__` to programatically generate a string from all public attributes. All objects that inherit from BaseItem had their `__repr__` deleted. Also added some missing attributes to some `__repr__`s