### PR TITLE
fix roblosecurity link

### DIFF
--- a/docs/tutorials/authentication.md
+++ b/docs/tutorials/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 To authenticate our client, we need our .ROBLOSECURITY token. To learn about why we need this and how to get it, 
-please see [ROBLOSECURITY](/roblosecurity). 
+please see [ROBLOSECURITY](/v2.0.0/tutorials/roblosecurity). 
 
 Once we have our token, we can add it to our client by passing it as the first parameter. 
 Use the following code and replace `TOKEN` with the .ROBLOSECURITY token grabbed earlier to authenticate your client.


### PR DESCRIPTION
"/roblosecurity" doesn't work, it redirects to "https://ro.py.jmk.gg/roblosecurity" instead of "https://ro.py.jmk.gg/v2.0.0/tutorials/roblosecurity/", so I'm just hardcoding it.